### PR TITLE
Fix for GPGWT-97

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -86,13 +86,12 @@ void compileGwtClasses(forceCompile = false) {
         //
         ant.mkdir(dir: gwtClassesDir)
         gwtJavac( destDir: gwtClassesDir, includes: "**/*.java") {
-            src(path: 'src/gwt')
+            src(path: 'src/gwt')//current project gwt modules
             //include any sources from any included plugins
             buildConfig?.gwt?.plugins?.each {pluginName ->
               def pluginDir = binding.variables["${pluginName}PluginDir"]
               if (pluginDir) {
                 src(path: "${pluginDir}/src/gwt")
-                src(path: "${pluginDir}/src/java")
               }
             }
             ant.classpath {


### PR DESCRIPTION
See http://jira.grails.org/browse/GPGWT-97

Basically this is very similar to : 

https://github.com/dawsonsystems/grails-gwt/commit/ee43b8e757ad9b2f402b22ba677e98f6ac016bc6

Except it's src paths instead of path elements.

This is required to run grails tests when you cross reference gwt modules between your main app and plugins.
