### PR TITLE
[GPGWT-117] Added "module" argument to script run-gwt-codeserver

### DIFF
--- a/scripts/_GwtInternal.groovy
+++ b/scripts/_GwtInternal.groovy
@@ -463,8 +463,11 @@ target (runCodeServer: "Runs the Super Dev Mode server.") {
             arg(value: "-bindAddress")
             arg(value: argsMap["bindAddress"])
         }
-
-        arg(line: modules.join(" "))
+        if(argsMap["module"]){
+	   arg(line: argsMap["module"])
+	}else{
+	   arg(line: modules.join(" "))
+	}
     }
 }
 


### PR DESCRIPTION
Hi I needed a way to specify a single module when running gwt superdevmode. It would be nice if something like this found its way into the next release.

To use it you would call the script like this:
grails run-gwt-codeserver -module=com.my.module

and the script shall only run the superdevmode for the specified module.
