### PR TITLE
Added support define args only to compilation process

### DIFF
--- a/src/groovy/org/codehaus/groovy/grails/plugins/gwt/GWTCompiler.groovy
+++ b/src/groovy/org/codehaus/groovy/grails/plugins/gwt/GWTCompiler.groovy
@@ -164,6 +164,12 @@ class GWTCompiler {
     try {
 
       def result = gwtRun(compilerClass, [resultproperty: "result", fork:true, output:"${logFile.absoluteFile}", error:"${logFile.absoluteFile}", append:true]) {
+          if (grailsSettings.config.gwt.compile.args) {
+              def c = grailsSettings.config.gwt.compile.args.clone()
+              c.delegate = delegate
+              c()
+          }
+
           jvmarg(value: '-Djava.awt.headless=true')
           arg(value: '-style')
           arg(value: gwtOutputStyle)


### PR DESCRIPTION
Hi, David!

I added support of `gwt.compile.args` configuration option.

It need to spit up args between run and compile processes:

``` groovy
gwt.compile.args = {
//  arg(value: '-strict')
  arg(value: '-XdisableClassMetadata')
  arg(value: '-XdisableCastChecking')
  arg(value: '-XenableClosureCompiler')
}

gwt.run.args = {
  jvmarg(value: '-Xms1024m')
  jvmarg(value: '-Xmx2048m')
}
```

It needs to fix fail problem when you start `run-gwt-codeserver` with all above listed parameters defined in one `gwt.run.args`. Because `com.google.gwt.dev.codeserver.CodeServer` doesn't support all of these parameters, like `-XdisableClassMetadata`, `-XdisableCastChecking`, ...
